### PR TITLE
add check for standalone annotation in pod webook

### DIFF
--- a/pkg/controller/jobs/pod/pod_webhook.go
+++ b/pkg/controller/jobs/pod/pod_webhook.go
@@ -56,6 +56,8 @@ const (
 	SuspendedByParentAnnotation  = "kueue.x-k8s.io/pod-suspending-parent"
 	RoleHashAnnotation           = "kueue.x-k8s.io/role-hash"
 	RetriableInGroupAnnotation   = "kueue.x-k8s.io/retriable-in-group"
+	// TODO: Not sure about the naming of this annotation
+	StandalonePodAnnotation = "kueue.x-k8s.io/standalone-pod"
 )
 
 var (
@@ -170,7 +172,9 @@ func (w *PodWebhook) Default(ctx context.Context, obj runtime.Object) error {
 		}
 
 		// Do not suspend a Pod whose owner is already managed by Kueue
-		if owner := metav1.GetControllerOf(pod.Object()); owner != nil {
+		// unless it is specified to be a standAlone pod, then we process it regardless of it's ownerRef
+		_, standAlone := pod.pod.GetAnnotations()[StandalonePodAnnotation]
+		if owner := metav1.GetControllerOf(pod.Object()); owner != nil && !standAlone {
 			if owner.Kind == "ReplicaSet" && owner.APIVersion == "apps/v1" {
 				// ReplicaSet is an implementation detail; skip over it to the user-facing framework
 				rs := &appsv1.ReplicaSet{}


### PR DESCRIPTION
create standalong pod annotation to allow for bypass of ownerRef check if the annotation exists on the pod. 