### PR TITLE
add check for standalone annotation in pod webook

### DIFF
--- a/pkg/controller/jobs/pod/pod_webhook.go
+++ b/pkg/controller/jobs/pod/pod_webhook.go
@@ -56,6 +56,8 @@ const (
 	SuspendedByParentAnnotation  = "kueue.x-k8s.io/pod-suspending-parent"
 	RoleHashAnnotation           = "kueue.x-k8s.io/role-hash"
 	RetriableInGroupAnnotation   = "kueue.x-k8s.io/retriable-in-group"
+	// TODO: Not sure about the naming of this annotation
+	StandalonePodAnnotation = "kueue.x-k8s.io/standalone-pod"
 )
 
 var (
@@ -170,7 +172,9 @@ func (w *PodWebhook) Default(ctx context.Context, obj runtime.Object) error {
 		}
 
 		// Do not suspend a Pod whose owner is already managed by Kueue
-		if owner := metav1.GetControllerOf(pod.Object()); owner != nil {
+		// unless it is specified to be a standAlone pod, then we process it regardless of it's ownerRef
+		_, standAlone := pod.pod.GetAnnotations()[StandalonePodAnnotation]
+		if owner := metav1.GetControllerOf(pod.Object()); owner != nil && !standAlone {
 			if owner.Kind == "ReplicaSet" && owner.APIVersion == "apps/v1" {
 				// ReplicaSet is an implementation detail; skip over it to the user-facing framework
 				rs := &appsv1.ReplicaSet{}

--- a/pkg/controller/jobs/pod/pod_webhook.go
+++ b/pkg/controller/jobs/pod/pod_webhook.go
@@ -56,8 +56,7 @@ const (
 	SuspendedByParentAnnotation  = "kueue.x-k8s.io/pod-suspending-parent"
 	RoleHashAnnotation           = "kueue.x-k8s.io/role-hash"
 	RetriableInGroupAnnotation   = "kueue.x-k8s.io/retriable-in-group"
-	// TODO: Not sure about the naming of this annotation
-	StandalonePodAnnotation = "kueue.x-k8s.io/standalone-pod"
+	StandalonePodAnnotation      = "kueue.datadoghq.com/standalone-pod"
 )
 
 var (


### PR DESCRIPTION
This PR will allow users to add an annotation `kueue.datadoghq.com/standalone-pod` that will allow for their pods to be processed even if they have an ownerRef that is a known integration to kueue. There are details on why this is needed in this issue in job platform: https://github.com/DataDog/job-platform/issues/54

I also intend to open an issue and propose this upstream, but will be helpful for us to have in our fork for now, until upstream may accept it. 