### PR TITLE
[dependabot npm disable] Temporarily disable npm version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,5 @@
 version: 2
 updates:
-
   # Maintain dependencies for go in root
   - package-ecosystem: "gomod"
     directories:
@@ -21,7 +20,6 @@ updates:
       # Allow patches and security updates.
       - dependency-name: k8s.io/*
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
-
   # Maintain npm dependencies for site
   - package-ecosystem: "npm"
     directory: "/site"
@@ -35,7 +33,7 @@ updates:
         update-types:
           - "minor"
           - "patch"
-
+    open-pull-requests-limit: 0
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -49,7 +47,6 @@ updates:
         update-types:
           - "minor"
           - "patch"
-
   # Maintain Dockerfiles
   - package-ecosystem: "docker"
     directories:
@@ -63,7 +60,6 @@ updates:
     labels:
       - "ok-to-test"
       - "release-note-none"
-
   # Maintain go dependencies for KueueViz backend
   - package-ecosystem: "gomod"
     directories:
@@ -82,7 +78,6 @@ updates:
       # Allow patches and security updates.
       - dependency-name: k8s.io/*
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
-
   # Maintain npm dependencies for KueueViz frontend
   - package-ecosystem: "npm"
     directory: "/cmd/kueueviz/frontend"
@@ -99,7 +94,7 @@ updates:
         update-types:
           - "minor"
           - "patch"
-
+    open-pull-requests-limit: 0
   # Maintain npm dependencies for KueueViz frontend cypress e2e tests
   - package-ecosystem: "npm"
     directory: "/test/e2e/kueueviz"
@@ -113,3 +108,4 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
This PR temporarily disables Dependabot **npm version updates** by setting `open-pull-requests-limit: 0` for all `package-ecosystem: npm` entries.

Use the matching `enable` script (or manually remove that field) to re-enable npm version updates later.